### PR TITLE
fix: resolve CI authentication and workflow configuration errors

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -25,12 +25,12 @@ body:
       render: protobuf
       placeholder: |
         syntax = "proto3";
-        
+
         message PageRequest {
           int32 page = 1;
           int32 page_size = 2;
         }
-        
+
         message PageResponse {
           int32 total_count = 1;
           int32 page = 2;

--- a/.github/workflows/buf-pr-checks.yml
+++ b/.github/workflows/buf-pr-checks.yml
@@ -9,6 +9,10 @@ on:
       - 'buf.gen.yaml'
       - '.github/workflows/buf-pr.yml'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   buf-checks:
     runs-on: ubuntu-latest
@@ -22,7 +26,7 @@ jobs:
       - name: Buf lint, format, breaking, and generate check
         uses: bufbuild/buf-action@v1
         with:
-          github_token: ${{ github.token }}
+          token: ${{ secrets.BUF_TOKEN }}
           push: false
           # Compare against the pull request's base branch in Git.
           # This is more robust than comparing against the BSR, as it avoids

--- a/.github/workflows/buf-pr-checks.yml
+++ b/.github/workflows/buf-pr-checks.yml
@@ -7,7 +7,7 @@ on:
       - 'proto/**'
       - 'buf.yaml'
       - 'buf.gen.yaml'
-      - '.github/workflows/buf-pr.yml'
+      - '.github/workflows/buf-pr-checks.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   buf-push:
     runs-on: ubuntu-latest
@@ -11,16 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Extract version from tag
-        id: version
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-
       - name: Buf push to BSR with release label
         uses: bufbuild/buf-action@v1
         with:
-          github_token: ${{ github.token }}
-          push: true
-          buf_token: ${{ secrets.BUF_TOKEN }}
-          buf_push_label: ${{ steps.version.outputs.version }}
+          token: ${{ secrets.BUF_TOKEN }}

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -19,3 +19,4 @@ jobs:
         uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
+          input: 'buf push --label "${{ github.event.release.tag_name }}"'

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 
  # macOS specific
  .DS_Store
+
+# Claude settings
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ The repository uses multiple automation layers for quality control and deploymen
 - **Push hooks**: Push schemas to BSR for remote code generation
 
 #### GitHub Actions
-- **PR Workflow** (`.github/workflows/buf-pr.yml`): Runs on all PR events including label changes
+- **PR Workflow** (`.github/workflows/buf-pr-checks.yml`): Runs on all PR events including label changes
   - Buf lint validation
   - Format checking with `buf format --diff --exit-code`
   - Breaking change detection against base branch
@@ -76,7 +76,7 @@ The repository uses multiple automation layers for quality control and deploymen
 - `buf.gen.yaml` - Code generation plugin configuration for BSR
 - `.pre-commit-config.yaml` - Hook definitions for quality gates
 - `.mise/config.toml` - Tool version management
-- `.github/workflows/buf-pr.yml` - GitHub Actions for PR validation
+- `.github/workflows/buf-pr-checks.yml` - GitHub Actions for PR validation
 - `.github/workflows/buf-release.yml` - GitHub Actions for release automation
 
 ### Using Generated Code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ The repository uses Buf Schema Registry (BSR) with remote code generation:
 - **Consumer Access**: Generated code available via Go modules and npm packages
 - **Plugins Used**:
   - `buf.build/protocolbuffers/go` - Standard Go protobuf generation
-  - `buf.build/connectrpc/go` - Connect RPC Go bindings  
+  - `buf.build/connectrpc/go` - Connect RPC Go bindings
   - `buf.build/bufbuild/es` - TypeScript protobuf generation
   - `buf.build/bufbuild/connect-es` - Connect RPC TypeScript bindings
   - `buf.build/bufbuild/validate-go` - Go validation code generation
@@ -125,7 +125,7 @@ When designing entities and RPC interfaces, follow these established standards:
 ### RPC Interface Design (Google AIP)
 - **Standard Methods**: Follow standard CRUD patterns
   - `Get{Resource}` for single resource retrieval
-  - `List{Resource}` for collection retrieval  
+  - `List{Resource}` for collection retrieval
   - `Create{Resource}` for resource creation
   - `Update{Resource}` for resource modification
   - `Delete{Resource}` for resource removal
@@ -189,7 +189,7 @@ Follow [Buf Documentation Guidelines](https://buf.build/docs/bsr/documentation) 
     // GetUser retrieves a single user by their unique identifier.
     // Returns NOT_FOUND if the user does not exist.
     rpc GetUser(GetUserRequest) returns (GetUserResponse);
-    
+
     // CreateUser creates a new user account with the provided information.
     // Returns ALREADY_EXISTS if a user with the same email already exists.
     rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
@@ -267,7 +267,7 @@ Follow [Buf Documentation Guidelines](https://buf.build/docs/bsr/documentation) 
   message GetUserRequest {
     string user_id = 1;
   }
-  
+
   // ✅ Good: Using user-defined types
   message GetUserRequest {
     entity.v1.UserId user_id = 1;


### PR DESCRIPTION
## 🔗 Related Issue

Closes #2

## 📝 Summary of Changes

This PR resolves critical GitHub Actions workflow authentication and configuration errors that were preventing successful BSR (Buf Schema Registry) publishing.

**What was the motivation for this change?**
The release workflow was failing with authentication errors and invalid parameter warnings, blocking the automated schema publishing pipeline.

**What problem does it solve?**
- Authentication failure: `"you are not authenticated for buf.build"` error during BSR push
- Invalid parameters: Warnings about unsupported inputs (`buf_token`, `buf_push_label`, etc.)
- Workflow inefficiency: Unnecessary complexity with manual version extraction

**What is the main technical approach?**
- Updated `buf_token` → `token` parameter for proper BSR authentication
- Added required permissions: `contents: read` and `pull-requests: write`
- Removed deprecated parameters and simplified workflow configuration
- Fixed formatting issues via pre-commit hooks

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.