### PR TITLE
fix: resolve buf-action input parameter error in release workflow

### DIFF
--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -15,9 +15,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Buf push to BSR with release label
+      - name: Setup buf CLI
         uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
-        env:
-          BUF_LABEL: ${{ github.event.release.tag_name }}
+          setup_only: true
+
+      - name: Push to BSR with release label
+        run: buf push --error-format github-actions --create --git-metadata --label "${{ github.event.release.tag_name }}"

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -19,4 +19,5 @@ jobs:
         uses: bufbuild/buf-action@v1
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          input: 'buf push --label "${{ github.event.release.tag_name }}"'
+        env:
+          BUF_LABEL: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## 🔗 Related Issue

Resolves workflow error from https://github.com/pannpers/protobuf-scaffold/actions/runs/16648643490/job/47115329600

## 📝 Summary of Changes

This PR fixes the critical error in the release workflow where buf-action was failing with `"The cwd: buf push --label "v1.2.1" does not exist\!"` error.

**What was the motivation for this change?**
The release workflow was incorrectly using the `input` parameter, causing buf-action to interpret the command string as a directory path instead of executing the intended BSR push command.

**What problem does it solve?**
- Fixes the "directory does not exist" error in release workflow
- Enables proper BSR push with release tag labels
- Ensures automated schema publishing works correctly on releases

**What is the main technical approach?**
- Removed incorrect `input` parameter usage that was causing the error  
- Implemented buf-action migration guide approach using `setup_only: true`
- Added direct `buf push` command with proper `--label` flag
- Added recommended flags: `--error-format github-actions`, `--create`, `--git-metadata`

## ✅ Self-Checklist

- [x] I have linked the related issue.
- [x] I have updated the relevant documentation (e.g., `README.md`) if needed.
- [x] I have run `buf lint` and `buf format` locally and all checks have passed.
- [x] My proto definitions follow the project's style guidelines and validation rules.
- [x] Breaking changes have been justified and documented if applicable.